### PR TITLE
Spezifischeres routen

### DIFF
--- a/backbone.yml
+++ b/backbone.yml
@@ -10,6 +10,6 @@
     - { role: tunearpcache, tags: "tunearpcache"}
     - { role: interfaces_ffrl, tags: "interfaces_ffrl"}
     - { role: interfaces_ffms_backbone, tags: "interfaces_ffms_backbone"}
-#    - { role: bird_backbone, tags: "bird_backbone"}
+    - { role: bird_backbone, tags: "bird_backbone"}
     - { role: collectd, tags: "collectd"}
 

--- a/roles/bird_backbone/templates/bird6.conf.j2
+++ b/roles/bird_backbone/templates/bird6.conf.j2
@@ -47,18 +47,35 @@ function is_default() {
 }
 
 filter hostroute {
-{% for domaene in ffms_routing.domaenen %}
-        if net ~ {{domaene.v6_net}} then accept;
+{% if 'ffms_tun_to' in hostvars[inventory_hostname] %}
+{% for domaene in range(01,99) %}
+{% set step = 0 %}
+{% for host in ffms_tun_to %}
+{% if 'domaene-'+'%02d' % domaene in hostvars[host.host_name].group_names and step == 0 %}
+        if net ~ {{hostvars[host.host_name].ff_network.v6_network | regex_replace('/\d+$','/56')}} then accept;
+{% set step = 1 %}
+{% endif %}
 {% endfor %}
+{% endfor %}
+{% endif %}
         reject;
 }
-{% for domaene in ffms_routing.domaenen %}
 
-protocol static static_{{domaene.group_name | replace("-","")}} {
+{% if 'ffms_tun_to' in hostvars[inventory_hostname] %}
+{% for domaene in range(01,99) %}
+{% set step = 0 %}
+{% for host in ffms_tun_to %}
+{% if 'domaene-'+'%02d' % domaene in hostvars[host.host_name].group_names and step == 0 %}
+protocol static static_domaene{{'%02d'%domaene}} {
         table ffnet;
-        route {{domaene.v6_net}} reject;
+        route {{hostvars[host.host_name].ff_network.v6_network | regex_replace('/\d+$','/56')}} reject;
 }
+
+{% set step = 1 %}
+{% endif %}
 {% endfor %}
+{% endfor %}
+{% endif %}
 
 # ibgp zwischen den gateways
 template bgp internal {

--- a/roles/bird_supernodes/tasks/main.yml
+++ b/roles/bird_supernodes/tasks/main.yml
@@ -20,7 +20,9 @@
    service: name=bird6 enabled=yes
 
  - name: Spezifischere Routen aus DHCP-Bereich berechnen
-   shell: 'ipcalc {{ dhcp.range_start }} - {{ dhcp.range_end}} |grep -v "deaggregate"|sed -e ''s/\(^.*$\)/route \1 via "bat0";/g'''
+   local_action: shell ipcalc {{ dhcp.range_start }} - {{ dhcp.range_end}} |grep -v "deaggregate"|sed -e 's/\(^.*$\)/route \1 via "bat0";/g'
+   always_run: yes
+   changed_when: false
    register: spezifische_Routen
    
  - name: configure bird.conf

--- a/roles/bird_supernodes/tasks/main.yml
+++ b/roles/bird_supernodes/tasks/main.yml
@@ -15,6 +15,14 @@
          - bird
          - bird6
 
+ - name: bird und bird6 automatisch starten
+   service: name=bird enabled=yes
+   service: name=bird6 enabled=yes
+
+ - name: Spezifischere Routen aus DHCP-Bereich berechnen
+   shell: 'ipcalc {{ dhcp.range_start }} - {{ dhcp.range_end}} |grep -v "deaggregate"|sed -e ''s/\(^.*$\)/route \1 via "bat0";/g'''
+   register: spezifische_Routen
+   
  - name: configure bird.conf
    template: src=bird.conf.j2 dest=/etc/bird/bird.conf
    notify:

--- a/roles/bird_supernodes/templates/bird.conf.j2
+++ b/roles/bird_supernodes/templates/bird.conf.j2
@@ -35,12 +35,22 @@ protocol device {
         scan time 10;           # Scan interfaces every 10 seconds
 };
 
+protocol static dhcp_Bereich {
+	table ffnet;
+{% for line in spezifische_Routen['stdout_lines'] %}
+	{{line}}
+{% endfor %}
+}
+
 
 protocol ospf 'p-ffnet-o' {
   table ffnet;
 #  rfc1583compat yes;
   import all;
-  export none;
+  export filter {
+	if source=RTS_STATIC_DEVICE then accept;
+	else reject;
+  };
 
   area 0.0.0.0 {
    interface "bat0" {

--- a/roles/bird_supernodes/templates/bird.conf.j2
+++ b/roles/bird_supernodes/templates/bird.conf.j2
@@ -37,6 +37,7 @@ protocol device {
 
 protocol static dhcp_Bereich {
 	table ffnet;
+	route {{ff_network.v4_network | ipaddr(server_id) | ipaddr('address') }}/32 via "bat0";
 {% for line in spezifische_Routen['stdout_lines'] %}
 	{{line}}
 {% endfor %}

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -35,6 +35,7 @@
     - socat
     - dnsutils
     - host
+    - ipcalc
 
 - name: add sshkeys for server
   authorized_key: 
@@ -46,4 +47,4 @@
 - locale_gen: name=de_DE.UTF-8 state=present
 
 - name: status.pl nach /root kopieren
-  copy: src=files/status.pl dest=/root/status.pl owner=root group=root mode=0755
+  copy: src=status.pl dest=/root/status.pl owner=root group=root mode=0755


### PR DESCRIPTION
Ich möchte das spezifische Routen von IPv4 gerne ausrollen, da es Querverkehr vermeidet, wenn mehrere VMs einer Domäne an demselben Backbone hängen.

Gibt es noch Bedenken?

Sonst bitte plus eins schreiben.
