### PR TITLE
added Digitalcourage e.V. DNS Server

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -489,6 +489,8 @@ bind:
   ffms_zone_masters:   
     - 89.163.231.228   
 
+public_dns_ip: 85.214.20.141
+
 logrotate:
   cycle: daily
   count: 3


### PR DESCRIPTION
https://digitalcourage.de/ (former FoeBuD e.V.)